### PR TITLE
Fix bug where switchProfile didn't work correctly

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ const sleep = util.promisify(setTimeout);
 /**
  * Logs into specified Netflix account and profile and performs action
  * specified by program.export
- * @param {{email: String, password: String, profile: String, export: String | Boolean, import: String | Boolean, shouldExport: Boolean, spaces: Number | Null}} args 
+ * @param {{email: String, password: String, profile: String, export: String | Boolean, import: String | Boolean, shouldExport: Boolean, spaces: Number | Null}} args
  */
 async function main(args, netflix = new Netflix()) {
   try {
@@ -45,7 +45,7 @@ async function main(args, netflix = new Netflix()) {
 
 /**
  * Prints error message to console and exits the process
- * @param {String | Error} message 
+ * @param {String | Error} message
  */
 main.exitWithMessage = function(message) {
   console.error(message);
@@ -64,8 +64,8 @@ main.waterfall = async function(promises) {
 
 /**
  * Gets profile guid from profile name
- * @param {netflix2} netflix 
- * @param {String} profileName 
+ * @param {netflix2} netflix
+ * @param {String} profileName
  * @returns {Promise} Promise that is resolved with guid once fetched
  */
 main.getProfileGuid = async function(netflix, profileName) {
@@ -75,7 +75,7 @@ main.getProfileGuid = async function(netflix, profileName) {
   if (profileWithCorrectName === undefined) {
     throw new Error(`No profile with name "${profileName}"`);
   } else {
-    return profileWithCorrectName;
+    return profileWithCorrectName.guid;
   }
 }
 

--- a/main.test.js
+++ b/main.test.js
@@ -84,16 +84,16 @@ describe('getProfileGuid', () => {
 	let netflixGetProfiles;
 	let netflix;
 	const profiles = [
-		{ firstName: 'Michael' },
-		{ firstName: 'Klaus' },
-		{ firstName: 'Carsten' },
-		{ firstName: 'Yannic' },
-		{ firstName: 'Franziska' },
-		{ firstName: 'Anna' },
-		{ firstName: 'Hanna' },
-		{ firstName: 'Marcel' },
-		{ firstName: '1234567890' },
-		{ firstName: 'What\'s wrong with you?' }
+		{ firstName: 'Michael', guid: '0' },
+		{ firstName: 'Klaus', guid: '1' },
+		{ firstName: 'Carsten', guid: '2' },
+		{ firstName: 'Yannic', guid: '3' },
+		{ firstName: 'Franziska', guid: '4' },
+		{ firstName: 'Anna', guid: '5' },
+		{ firstName: 'Hanna', guid: '6' },
+		{ firstName: 'Marcel', guid: '7' },
+		{ firstName: '1234567890', guid: '8' },
+		{ firstName: 'What\'s wrong with you?', guid: '9' }
 	];
 
 	beforeEach(() => {
@@ -106,14 +106,14 @@ describe('getProfileGuid', () => {
 		expect(getProfileGuid(netflix, '')).to.be.instanceOf(Promise);
 	});
 
-	it('Should resolve promise with correct profile', async () => {
+	it('Should resolve promise with correct profile guid', async () => {
 		netflixGetProfiles.resolves(profiles);
 
 		for (const profile of profiles) {
 			const result = getProfileGuid(netflix, profile.firstName);
 
 			await expect(result).to.eventually.be.fulfilled;
-			await expect(result).to.eventually.become(profile);
+			await expect(result).to.eventually.become(profile.guid);
 		}
   });
 


### PR DESCRIPTION
main.getProfileGuid returned the whole profile instead of instead of
the profile guid, which was then passed along to netflix2, which
expected the guid.