### PR TITLE
Add functionality to import thumb ratings

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,8 +13,8 @@ Netflix.prototype.login = util.promisify(Netflix.prototype.login);
 Netflix.prototype.getProfiles = util.promisify(Netflix.prototype.getProfiles);
 Netflix.prototype.switchProfile = util.promisify(Netflix.prototype.switchProfile);
 Netflix.prototype.getRatingHistory = util.promisify(Netflix.prototype.getRatingHistory);
-Netflix.prototype.setVideoRating = util.promisify(Netflix.prototype.setVideoRating);
-// Netflix.prototype.setThumbRating = util.promisify(Netflix.prototype.setThumbRating);
+Netflix.prototype.setStarRating = util.promisify(Netflix.prototype.setStarRating);
+Netflix.prototype.setThumbRating = util.promisify(Netflix.prototype.setThumbRating);
 const sleep = util.promisify(setTimeout);
 
 /**
@@ -144,7 +144,7 @@ main.getRatingHistory = async function(netflix, fileName, spaces) {
  * @returns {Promise} Promise that is resolved after setting the last rating
  */
 main.setRatingHistory = async function(netflix, filename) {
-  var jsonRatings;
+  let jsonRatings;
 
   if (filename === undefined) {
     jsonRatings = process.stdin.read();
@@ -152,15 +152,15 @@ main.setRatingHistory = async function(netflix, filename) {
     jsonRatings = fs.readFileSync(filename);
   }
 
-  var ratings = JSON.parse(jsonRatings);
+  let ratings = JSON.parse(jsonRatings);
 
   return main.waterfall(ratings.map(rating => async () => {
     try {
-      //if (rating.ratingType === 'thumb') {
-      //  await netflix.setThumbRating(rating.movieID, rating.yourRating);
-      //} else {
-        await netflix.setVideoRating(rating.movieID, rating.yourRating);
-      //}
+      if (rating.ratingType === 'thumb') {
+        await netflix.setThumbRating(rating.movieID, rating.yourRating);
+      } else {
+        await netflix.setStarRating(rating.movieID, rating.yourRating);
+      }
     } catch (e) {
       console.error(e);
       throw new Error('Could not set rating for ' + rating.name + '. For more information, please see ' +

--- a/main.js
+++ b/main.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-require('array.prototype.find').shim();
 const fs = require('fs');
 const Netflix = require('netflix2');
 const util = require('util');
@@ -99,7 +98,7 @@ main.getProfileGuid = async function(netflix, profileName) {
  */
 main.switchProfile = async function(netflix, guid) {
   try {
-    return netflix.switchProfile(guid);
+    return await netflix.switchProfile(guid);
   } catch (e) {
     console.error(e);
     throw new Error('Could not switch profiles. For more information, please see previous log statements.');

--- a/main.test.js
+++ b/main.test.js
@@ -83,7 +83,7 @@ describe('waterfall', () => {
 });
 
 describe('getProfileGuid', () => {
-	let netflixGetProfiles;
+	let netflixGetProfiles, consoleError;
 	let netflix;
 	const profiles = [
 		{firstName: 'Michael', guid: '0'},
@@ -102,6 +102,12 @@ describe('getProfileGuid', () => {
 		netflix = new Netflix();
 		netflixGetProfiles = sinon.stub(netflix, 'getProfiles')
 			.resolves([{firstName: ''}]);
+		consoleError = sinon.stub(console, 'error');
+	});
+	
+	afterEach(() => {
+		netflixGetProfiles.restore();
+		consoleError.restore();
 	});
 	
 	it('Should return a Promise', () => {
@@ -126,10 +132,30 @@ describe('getProfileGuid', () => {
 		
 		await expect(result).to.eventually.be.rejected;
 	});
+	
+	it('Should log any error thrown by netflix.getProfiles', async () => {
+		const error = new Error('Error thrown by test');
+		netflixGetProfiles.rejects(error);
+		
+		try {
+			await getProfileGuid(netflix, '');
+		} catch (e) {
+		
+		} finally {
+			expect(consoleError).to.have.been.calledOnce;
+			expect(consoleError).to.have.been.calledWithExactly(error);
+		}
+	});
+	
+	it('Should throw an error when netflix.getProfiles throws an error', async () => {
+		netflixGetProfiles.rejects(new Error());
+		
+		await expect(getProfileGuid(netflix, '')).to.eventually.be.rejected;
+	});
 });
 
 describe('switchProfile', () => {
-	let netflix, netflixSwitchProfile;
+	let netflix, netflixSwitchProfile, consoleError;
 	const guid = {foo: 'bar'};
 	const result = {so: 'amazing'};
 	
@@ -137,6 +163,12 @@ describe('switchProfile', () => {
 		netflix = new Netflix();
 		netflixSwitchProfile = sinon.stub(netflix, 'switchProfile')
 			.resolves(result);
+		consoleError = sinon.stub(console, 'error');
+	});
+	
+	afterEach(() => {
+		netflixSwitchProfile.restore();
+		consoleError.restore();
 	});
 	
 	it('Should return a promise', () => {
@@ -148,10 +180,30 @@ describe('switchProfile', () => {
 		expect(netflixSwitchProfile).to.have.been.calledWithExactly(guid);
 		expect(res).to.deep.equal(result);
 	});
+	
+	it('Should log any error thrown by netflix.switchProfile', async () => {
+		const error = new Error('Error thrown by test');
+		netflixSwitchProfile.rejects(error);
+		
+		try {
+			await switchProfile(netflix, guid);
+		} catch (e) {
+		
+		} finally {
+			expect(consoleError).to.have.been.calledOnce;
+			expect(consoleError).to.have.been.calledWithExactly(error);
+		}
+	});
+	
+	it('Should throw an error when netflix.switchProfile throws an error', async () => {
+		netflixSwitchProfile.rejects(new Error());
+		
+		await expect(switchProfile(netflix, guid)).to.eventually.be.rejected;
+	});
 });
 
 describe('getRatingHistory', () => {
-	let netflix, netflixGetRatingHistory, processStdoutWrite, fsWriteFileSync;
+	let netflix, netflixGetRatingHistory, processStdoutWrite, fsWriteFileSync, consoleError;
 	const filename = 'test.json';
 	const ratings = [
 		{
@@ -183,6 +235,7 @@ describe('getRatingHistory', () => {
 		netflix = new Netflix();
 		netflixGetRatingHistory = sinon.stub(netflix, 'getRatingHistory')
 			.resolves(ratings);
+		consoleError = sinon.stub(console, 'error');
 		processStdoutWrite = sinon.stub(process.stdout, 'write');
 		fsWriteFileSync = sinon.stub(fs, 'writeFileSync');
 	});
@@ -191,6 +244,7 @@ describe('getRatingHistory', () => {
 		netflixGetRatingHistory.restore();
 		processStdoutWrite.restore();
 		fsWriteFileSync.restore();
+		consoleError.restore();
 	});
 	
 	it('Should return a promise', () => {
@@ -223,10 +277,30 @@ describe('getRatingHistory', () => {
 		await getRatingHistory(netflix, filename, 4);
 		expect(fsWriteFileSync).to.have.been.calledOnceWith(filename, ratingsJSONWith4Spaces);
 	});
+	
+	it('Should log any error thrown by netflix.switchProfile', async () => {
+		const error = new Error('Error thrown by test');
+		netflixGetRatingHistory.rejects(error);
+		
+		try {
+			await getRatingHistory(netflix, filename, 4);
+		} catch (e) {
+		
+		} finally {
+			expect(consoleError).to.have.been.calledOnce;
+			expect(consoleError).to.have.been.calledWithExactly(error);
+		}
+	});
+	
+	it('Should throw an error when netflix.switchProfile throws an error', async () => {
+		netflixGetRatingHistory.rejects(new Error());
+		
+		await expect(getRatingHistory(netflix, filename, 4)).to.eventually.be.rejected;
+	});
 });
 
 describe('setRatingHistory', () => {
-	let netflix, netflixSetStarRating, netflixSetThumbRating, processStdinRead, fsReadFileSync;
+	let netflix, netflixSetStarRating, netflixSetThumbRating, processStdinRead, fsReadFileSync, consoleError;
 	const filename = 'test.json';
 	const ratings = [
 		{
@@ -265,6 +339,8 @@ describe('setRatingHistory', () => {
 			.returns(ratingsJSON);
 		fsReadFileSync = sinon.stub(fs, 'readFileSync')
 			.returns(ratingsJSON);
+		
+		consoleError = sinon.stub(console, 'error');
 	});
 	
 	afterEach(() => {
@@ -272,6 +348,7 @@ describe('setRatingHistory', () => {
 		netflixSetThumbRating.restore();
 		processStdinRead.restore();
 		fsReadFileSync.restore();
+		consoleError.restore();
 	});
 	
 	it('Should return a promise', () => {

--- a/main.test.js
+++ b/main.test.js
@@ -1,5 +1,5 @@
 const chai = require('chai');
-const { expect } = chai;
+const {expect} = chai;
 const chaiAsPromised = require('chai-as-promised');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
@@ -7,7 +7,7 @@ chai.use(chaiAsPromised);
 chai.use(sinonChai);
 
 const main = require('./main');
-const { waterfall, getProfileGuid, switchProfile, getRatingHistory, setRatingHistory, exitWithMessage } = main;
+const {waterfall, getProfileGuid, switchProfile, getRatingHistory, setRatingHistory, exitWithMessage} = main;
 const Netflix = require('netflix2');
 const fs = require('fs');
 
@@ -48,30 +48,32 @@ describe('exitWithMessage', () => {
 
 describe('waterfall', () => {
 	let promises = [];
-
+	
 	beforeEach(() => {
 		promises = [];
-
+		
 		for (let i = 0; i < 10; i++) {
 			promises.push(
 				sinon
 					.stub()
-					.callsFake(() => new Promise((resolve) => setTimeout(() => { resolve(); }, 10)))
+					.callsFake(() => new Promise((resolve) => setTimeout(() => {
+						resolve();
+					}, 10)))
 			);
 		}
 	});
-
+	
 	it('Should return a promise', () => {
 		expect(waterfall([])).to.be.instanceOf(Promise);
 	});
-
+	
 	it('Should execute all promises', async () => {
 		await waterfall(promises);
 		for (const promise of promises) {
 			expect(promise).to.have.been.calledOnce;
 		}
-  });
-
+	});
+	
 	it('Should execute all promises in correct order', async () => {
 		await waterfall(promises);
 		for (let i = 1; i < promises.length; i++) {
@@ -84,63 +86,63 @@ describe('getProfileGuid', () => {
 	let netflixGetProfiles;
 	let netflix;
 	const profiles = [
-		{ firstName: 'Michael', guid: '0' },
-		{ firstName: 'Klaus', guid: '1' },
-		{ firstName: 'Carsten', guid: '2' },
-		{ firstName: 'Yannic', guid: '3' },
-		{ firstName: 'Franziska', guid: '4' },
-		{ firstName: 'Anna', guid: '5' },
-		{ firstName: 'Hanna', guid: '6' },
-		{ firstName: 'Marcel', guid: '7' },
-		{ firstName: '1234567890', guid: '8' },
-		{ firstName: 'What\'s wrong with you?', guid: '9' }
+		{firstName: 'Michael', guid: '0'},
+		{firstName: 'Klaus', guid: '1'},
+		{firstName: 'Carsten', guid: '2'},
+		{firstName: 'Yannic', guid: '3'},
+		{firstName: 'Franziska', guid: '4'},
+		{firstName: 'Anna', guid: '5'},
+		{firstName: 'Hanna', guid: '6'},
+		{firstName: 'Marcel', guid: '7'},
+		{firstName: '1234567890', guid: '8'},
+		{firstName: 'What\'s wrong with you?', guid: '9'}
 	];
-
+	
 	beforeEach(() => {
 		netflix = new Netflix();
 		netflixGetProfiles = sinon.stub(netflix, 'getProfiles')
-			.resolves([{ firstName: '' }]);
+			.resolves([{firstName: ''}]);
 	});
-
+	
 	it('Should return a Promise', () => {
 		expect(getProfileGuid(netflix, '')).to.be.instanceOf(Promise);
 	});
-
+	
 	it('Should resolve promise with correct profile guid', async () => {
 		netflixGetProfiles.resolves(profiles);
-
+		
 		for (const profile of profiles) {
 			const result = getProfileGuid(netflix, profile.firstName);
-
+			
 			await expect(result).to.eventually.be.fulfilled;
 			await expect(result).to.eventually.become(profile.guid);
 		}
-  });
-
+	});
+	
 	it('Should reject promise when no matching profile is found', async () => {
 		netflixGetProfiles.resolves(profiles);
-
+		
 		const result = getProfileGuid(netflix, 'Non-existent name');
-
+		
 		await expect(result).to.eventually.be.rejected;
 	});
 });
 
 describe('switchProfile', () => {
 	let netflix, netflixSwitchProfile;
-	const guid = { foo: 'bar' };
-	const result = { so: 'amazing' };
-
+	const guid = {foo: 'bar'};
+	const result = {so: 'amazing'};
+	
 	beforeEach(() => {
 		netflix = new Netflix();
 		netflixSwitchProfile = sinon.stub(netflix, 'switchProfile')
 			.resolves(result);
 	});
-
+	
 	it('Should return a promise', () => {
 		expect(switchProfile(netflix, guid)).to.be.instanceOf(Promise);
 	});
-
+	
 	it('Should call netflix.switchProfile and return it\'s value', async () => {
 		const res = await switchProfile(netflix, guid);
 		expect(netflixSwitchProfile).to.have.been.calledWithExactly(guid);
@@ -172,11 +174,11 @@ describe('getRatingHistory', () => {
 			'comparableDate': 2234567890
 		}
 	];
-
+	
 	// JSON representations are hard coded into this test in order to notice when JSON.stringify changes
 	const ratingsJSON = '[{"ratingType":"star","title":"Some movie","movieID":12345678,"yourRating":5,"intRating":50,"date":"01/02/2016","timestamp":1234567890123,"comparableDate":1234567890},{"ratingType":"thumb","title":"Amazing Show","movieID":87654321,"yourRating":2,"date":"02/02/2018","timestamp":2234567890123,"comparableDate":2234567890}]';
 	const ratingsJSONWith4Spaces = '[\n    {\n        "ratingType": "star",\n        "title": "Some movie",\n        "movieID": 12345678,\n        "yourRating": 5,\n        "intRating": 50,\n        "date": "01/02/2016",\n        "timestamp": 1234567890123,\n        "comparableDate": 1234567890\n    },\n    {\n        "ratingType": "thumb",\n        "title": "Amazing Show",\n        "movieID": 87654321,\n        "yourRating": 2,\n        "date": "02/02/2018",\n        "timestamp": 2234567890123,\n        "comparableDate": 2234567890\n    }\n]';
-
+	
 	beforeEach(() => {
 		netflix = new Netflix();
 		netflixGetRatingHistory = sinon.stub(netflix, 'getRatingHistory')
@@ -184,39 +186,39 @@ describe('getRatingHistory', () => {
 		processStdoutWrite = sinon.stub(process.stdout, 'write');
 		fsWriteFileSync = sinon.stub(fs, 'writeFileSync');
 	});
-
+	
 	afterEach(() => {
 		netflixGetRatingHistory.restore();
 		processStdoutWrite.restore();
 		fsWriteFileSync.restore();
 	});
-
+	
 	it('Should return a promise', () => {
 		expect(getRatingHistory(netflix, filename, null)).to.be.instanceOf(Promise);
 	});
-
+	
 	it('Should only print to process.stdout when filename is not specified', async () => {
 		await getRatingHistory(netflix, undefined, null);
 		expect(processStdoutWrite).to.have.been.calledOnce;
 		expect(fsWriteFileSync).to.not.have.been.called;
 	});
-
+	
 	it('Should only print to file when filename is specified', async () => {
 		await getRatingHistory(netflix, filename, null);
 		expect(fsWriteFileSync).to.have.been.calledOnce;
 		expect(processStdoutWrite).to.not.have.been.called;
 	});
-
+	
 	it('Should print correct JSON to process.stdout', async () => {
 		await getRatingHistory(netflix, undefined, null);
 		expect(processStdoutWrite).to.have.been.calledOnceWith(ratingsJSON);
 	});
-
+	
 	it('Should print correct JSON to file', async () => {
 		await getRatingHistory(netflix, filename, null);
 		expect(fsWriteFileSync).to.have.been.calledOnceWith(filename, ratingsJSON);
 	});
-
+	
 	it('Should print correct JSON when spaces is specified', async () => {
 		await getRatingHistory(netflix, filename, 4);
 		expect(fsWriteFileSync).to.have.been.calledOnceWith(filename, ratingsJSONWith4Spaces);
@@ -224,7 +226,7 @@ describe('getRatingHistory', () => {
 });
 
 describe('setRatingHistory', () => {
-	let netflix, netflixSetVideoRating, processStdinRead, fsReadFileSync;
+	let netflix, netflixSetStarRating, netflixSetThumbRating, processStdinRead, fsReadFileSync;
 	const filename = 'test.json';
 	const ratings = [
 		{
@@ -247,103 +249,129 @@ describe('setRatingHistory', () => {
 			'comparableDate': 2234567890
 		}
 	];
-
+	const starRatings = ratings.filter(rating => rating.ratingType === 'star');
+	const thumbRatings = ratings.filter(rating => rating.ratingType === 'thumb');
+	
 	// JSON representation is hard coded into this test in order to notice when JSON.stringify changes
 	const ratingsJSON = '[{"ratingType":"star","title":"Some movie","movieID":12345678,"yourRating":5,"intRating":50,"date":"01/02/2016","timestamp":1234567890123,"comparableDate":1234567890},{"ratingType":"thumb","title":"Amazing Show","movieID":87654321,"yourRating":2,"date":"02/02/2018","timestamp":2234567890123,"comparableDate":2234567890}]';
-
+	
 	beforeEach(() => {
 		netflix = new Netflix();
-		netflixSetVideoRating = sinon.stub(netflix, 'setVideoRating')
+		netflixSetStarRating = sinon.stub(netflix, 'setStarRating')
+			.resolves();
+		netflixSetThumbRating = sinon.stub(netflix, 'setThumbRating')
 			.resolves();
 		processStdinRead = sinon.stub(process.stdin, 'read')
 			.returns(ratingsJSON);
 		fsReadFileSync = sinon.stub(fs, 'readFileSync')
 			.returns(ratingsJSON);
 	});
-
+	
 	afterEach(() => {
-		netflixSetVideoRating.restore();
+		netflixSetStarRating.restore();
+		netflixSetThumbRating.restore();
 		processStdinRead.restore();
 		fsReadFileSync.restore();
 	});
-
+	
 	it('Should return a promise', () => {
 		processStdinRead.returns('[]');
 		expect(setRatingHistory(netflix)).to.be.instanceOf(Promise);
 	});
-
+	
 	it('Should read rating history from file when filename is specified', async () => {
 		await setRatingHistory(netflix, filename);
 		expect(fsReadFileSync).to.have.been.calledOnce;
 		expect(fsReadFileSync).to.have.been.calledWithExactly(filename);
 		expect(processStdinRead).to.not.have.been.calledOnce;
 	});
-
+	
 	it('Should read rating history from stdin when filename is not specified', async () => {
 		await setRatingHistory(netflix);
 		expect(processStdinRead).to.have.been.calledOnce;
 		expect(fsReadFileSync).to.not.have.been.calledOnce;
 	});
-
+	
 	it('Should take about 100ms per rating due to timeout between requests', async () => {
 		const beginning = Date.now().valueOf();
 		await setRatingHistory(netflix);
 		const end = Date.now().valueOf();
 		expect(end - beginning).to.not.be.lessThan(ratings.length * 100);
 	});
-
-	it('Should call netflix.setVideoRating once per rating', async () => {
+	
+	it('Should call netflix.setStarRating once per star rating', async () => {
 		await setRatingHistory(netflix);
-		expect(netflixSetVideoRating).to.have.callCount(ratings.length);
-
-		for (const rating of ratings) {
-			expect(netflixSetVideoRating).to.have.been.calledWithExactly(rating.movieID, rating.yourRating);
+		expect(netflixSetStarRating).to.have.callCount(starRatings.length);
+		
+		for (const rating of starRatings) {
+			expect(netflixSetStarRating).to.have.been.calledWithExactly(rating.movieID, rating.yourRating);
 		}
-  });
-  
-  it('Should call main.waterfall once with an array of functions that return promises', async () => {
-    const waterfallStub = sinon.stub(main, 'waterfall').resolves();
-    
-    await setRatingHistory(netflix);
-    
-    expect(waterfallStub).to.have.been.calledOnce;
-    const functions = waterfallStub.args[0][0];
-    expect(functions).to.have.lengthOf(ratings.length);
-    
-    for (const func of functions) {
-      expect(func).to.be.instanceOf(Function);
-      expect(func()).to.be.instanceOf(Promise);
-    }
-    
-    waterfallStub.restore();
-  });
-
-	it('Should call main.waterfall once with an array of functions', async () => {
-		const waterfallStub = sinon.stub(main, 'waterfall').resolves();
-
+	});
+	
+	it('Should call netflix.setThumbRating once per thumb rating', async () => {
 		await setRatingHistory(netflix);
-
+		expect(netflixSetThumbRating).to.have.callCount(thumbRatings.length);
+		
+		for (const rating of thumbRatings) {
+			expect(netflixSetThumbRating).to.have.been.calledWithExactly(rating.movieID, rating.yourRating);
+		}
+	});
+	
+	it('Should call main.waterfall once with an array of functions that return promises', async () => {
+		const waterfallStub = sinon.stub(main, 'waterfall').resolves();
+		
+		await setRatingHistory(netflix);
+		
 		expect(waterfallStub).to.have.been.calledOnce;
 		const functions = waterfallStub.args[0][0];
-
+		expect(functions).to.have.lengthOf(ratings.length);
+		
 		for (const func of functions) {
-			netflixSetVideoRating.resolves();
+			expect(func).to.be.instanceOf(Function);
+			expect(func()).to.be.instanceOf(Promise);
+		}
+		
+		waterfallStub.restore();
+	});
+	
+	it('Should call main.waterfall once with an array of functions', async () => {
+		const waterfallStub = sinon.stub(main, 'waterfall').resolves();
+		
+		await setRatingHistory(netflix);
+		
+		expect(waterfallStub).to.have.been.calledOnce;
+		const functions = waterfallStub.args[0][0];
+		
+		for (const func of functions) {
+			netflixSetStarRating.resolves();
+			netflixSetThumbRating.resolves();
 			await expect(func()).to.eventually.be.fulfilled;
-
-			netflixSetVideoRating.rejects(new Error());
+			
+			netflixSetStarRating.rejects(new Error());
+			netflixSetThumbRating.rejects(new Error());
 			await expect(func()).to.eventually.be.rejected;
 		}
-    
-    waterfallStub.restore();
+		
+		waterfallStub.restore();
 	});
-
-	it('Should call netflix.setVideoRating in correct order', async () => {
+	
+	it('Should call netflix.setStarRating in correct order', async () => {
 		await setRatingHistory(netflix);
-		for (let i = 0; i < ratings.length; i++) {
-			expect(netflixSetVideoRating.getCall(i))
+		for (let i = 0; i < starRatings.length; i++) {
+			expect(netflixSetStarRating.getCall(i))
 				.to.have.been.calledWithExactly(
-					ratings[i].movieID, ratings[i].yourRating
-				);
+				starRatings[i].movieID, starRatings[i].yourRating
+			);
+		}
+	});
+	
+	it('Should call netflix.setThumbRating in correct order', async () => {
+		await setRatingHistory(netflix);
+		for (let i = 0; i < thumbRatings.length; i++) {
+			expect(netflixSetThumbRating.getCall(i))
+				.to.have.been.calledWithExactly(
+				thumbRatings[i].movieID, thumbRatings[i].yourRating
+			);
 		}
 	});
 });
@@ -351,141 +379,141 @@ describe('setRatingHistory', () => {
 describe('main', () => {
 	let netflix, netflixLogin, mainGetProfileGuid, mainSwitchProfile, mainGetRatingHistory,
 		mainSetRatingHistory, mainExitWithMessage, stubs, args;
-	const profile = { guid: 1234567890, firstName: 'Foo' };
-
+	const profile = {guid: 1234567890, firstName: 'Foo'};
+	
 	beforeEach(() => {
 		netflix = new Netflix();
 		args = {};
-
+		
 		netflixLogin = sinon.stub(netflix, 'login')
 			.resolves();
-
+		
 		mainExitWithMessage = sinon.stub(main, 'exitWithMessage');
-
+		
 		mainGetProfileGuid = sinon.stub(main, 'getProfileGuid')
 			.resolves(profile);
-
+		
 		mainSwitchProfile = sinon.stub(main, 'switchProfile')
 			.resolves();
-
+		
 		mainGetRatingHistory = sinon.stub(main, 'getRatingHistory')
 			.resolves();
-
+		
 		mainSetRatingHistory = sinon.stub(main, 'setRatingHistory')
 			.resolves();
-
+		
 		stubs = [
 			netflixLogin, mainExitWithMessage, mainGetProfileGuid, mainSwitchProfile,
 			mainGetRatingHistory, mainSetRatingHistory
 		];
 	});
-
+	
 	afterEach(() => {
 		stubs.forEach(stub => stub.restore());
 	});
-
+	
 	it('Should return a promise', () => {
 		expect(main(args, netflix)).to.be.instanceOf(Promise);
 	});
-
+	
 	it('Should call netflix.login with args.email and args.password', async () => {
-		args.email = { foo: 'bar' };
-		args.password = { bar: 'foo' };
-
+		args.email = {foo: 'bar'};
+		args.password = {bar: 'foo'};
+		
 		await main(args, netflix);
 		expect(netflixLogin).to.have.been.calledOnceWithExactly({
-			email: args.email,
-			password: args.password
-		})
+																	email: args.email,
+																	password: args.password
+																})
 	});
-
+	
 	it('Should call main.getProfileGuid after netflix.login', async () => {
 		await main(args, netflix);
 		expect(mainGetProfileGuid).to.have.been.calledAfter(netflixLogin);
 	});
-
+	
 	it('Should call main.getProfileGuid with args.profile', async () => {
-		args.profile = { foo: 'bar' };
-
+		args.profile = {foo: 'bar'};
+		
 		await main(args, netflix);
 		expect(mainGetProfileGuid).to.have.been.calledOnceWithExactly(netflix, args.profile);
 	});
-
+	
 	it('Should call main.switchProfile after main.getProfileGuid', async () => {
 		await main(args, netflix);
 		expect(mainSwitchProfile).to.have.been.calledAfter(mainGetProfileGuid);
 	});
-
+	
 	it('Should call main.switchProfile with the result of main.getProfileGuid', async () => {
 		await main(args, netflix);
 		expect(mainSwitchProfile).to.have.been.calledOnceWithExactly(netflix, profile);
 	});
-
+	
 	describe('Should call main.getRatingHistory', () => {
 		beforeEach(() => {
 			args.shouldExport = true;
 		});
-
+		
 		it('if args.shouldExport is true', async () => {
 			await main(args, netflix);
 			expect(mainGetRatingHistory).to.have.been.calledOnce;
 			expect(mainSetRatingHistory).to.not.have.been.called;
 		});
-
+		
 		it('with an undefined filename if args.export is true', async () => {
 			args.export = true;
 			await main(args, netflix);
 			expect(mainGetRatingHistory).to.have.been.calledOnceWithExactly(netflix, undefined, undefined);
 		});
-
+		
 		it('with filename provided in args.export', async () => {
-			args.export = { foo: 'bar' };
+			args.export = {foo: 'bar'};
 			await main(args, netflix);
 			expect(mainGetRatingHistory).to.have.been.calledOnceWithExactly(netflix, args.export, undefined);
 		});
-
+		
 		it('with args.spaces', async () => {
 			args.export = true;
-			args.spaces = { foo: 'bar' };
+			args.spaces = {foo: 'bar'};
 			await main(args, netflix);
 			expect(mainGetRatingHistory).to.have.been.calledOnceWithExactly(netflix, undefined, args.spaces);
 		});
-
+		
 		it('after main.switchProfile', async () => {
 			await main(args, netflix);
 			expect(mainGetRatingHistory).to.have.been.calledAfter(mainSwitchProfile);
 		});
 	});
-
+	
 	describe('Should call main.setRatingHistory', () => {
 		beforeEach(() => {
 			args.shouldExport = false;
 		});
-
+		
 		it('if args.shouldExport is false', async () => {
 			await main(args, netflix);
 			expect(mainSetRatingHistory).to.have.been.calledOnce;
 			expect(mainGetRatingHistory).to.not.have.been.called;
 		});
-
+		
 		it('with an undefined filename if args.import is true', async () => {
 			args.import = true;
 			await main(args, netflix);
 			expect(mainSetRatingHistory).to.have.been.calledOnceWithExactly(netflix, undefined);
 		});
-
+		
 		it('with filename provided in args.import', async () => {
-			args.import = { foo: 'bar' };
+			args.import = {foo: 'bar'};
 			await main(args, netflix);
 			expect(mainSetRatingHistory).to.have.been.calledOnceWithExactly(netflix, args.import);
 		});
-
+		
 		it('after main.switchProfile', async () => {
 			await main(args, netflix);
 			expect(mainSetRatingHistory).to.have.been.calledAfter(mainSwitchProfile);
 		});
 	});
-
+	
 	describe('Should call main.exitWithMessage immediately when an error is thrown', () => {
 		it('by netflix.login', async () => {
 			const err = new Error();
@@ -493,19 +521,19 @@ describe('main', () => {
 			await main(args, netflix);
 			expect(mainExitWithMessage).to.have.been.calledOnceWithExactly(err);
 		});
-
+		
 		const functionsToTest = [
 			// @todo make this work with netflix
 			// { name: 'netflix.login', parent: netflix },
-			{ name: 'main.getProfileGuid', parent: main, args: {} },
-			{ name: 'main.switchProfile', parent: main, args: {} },
-			{ name: 'main.getRatingHistory', parent: main, args: { shouldExport: true } },
-			{ name: 'main.setRatingHistory', parent: main, args: { shouldExport: false } }
+			{name: 'main.getProfileGuid', parent: main, args: {}},
+			{name: 'main.switchProfile', parent: main, args: {}},
+			{name: 'main.getRatingHistory', parent: main, args: {shouldExport: true}},
+			{name: 'main.setRatingHistory', parent: main, args: {shouldExport: false}}
 		];
-
+		
 		for (let i = 0; i < functionsToTest.length; i++) {
 			let func = functionsToTest[i];
-
+			
 			it(`by ${func.name}`, async () => {
 				const err = new Error();
 				const parts = func.name.split('.');
@@ -513,7 +541,7 @@ describe('main', () => {
 				await main(func.args, netflix);
 				expect(mainExitWithMessage).to.have.been.calledOnce;
 				expect(mainExitWithMessage).to.have.been.calledOnceWithExactly(err);
-
+				
 				for (let j = i + 1; j < functionsToTest.length; j++) {
 					const laterFunctionName = functionsToTest[j].name.split('.')[1];
 					const laterFunction = functionsToTest[j].parent[laterFunctionName];

--- a/package-lock.json
+++ b/package-lock.json
@@ -763,9 +763,9 @@
       }
     },
     "domelementtype": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
-      "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domhandler": {
       "version": "2.3.0",
@@ -1724,9 +1724,9 @@
       "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
     },
     "netflix2": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/netflix2/-/netflix2-0.0.8.tgz",
-      "integrity": "sha512-ScH90Ndmdt0EuWkzuZrOu4pzTcvi4wslLejcfojneve2rSbns9EAyu486U4eOYwJV4l0UBEoVSCYnmFbbxvCBw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/netflix2/-/netflix2-0.1.1.tgz",
+      "integrity": "sha512-Mk+a6ocKLv6QWAXsmndLlqXmUULpA3WDIknforJbG8pdPf9kO5C6XXlrqdCx3HL9lFWPIi1K2tLZfCUl7n8Rqg==",
       "requires": {
         "async": "^2.0.0-rc.5",
         "cheerio": "^0.20.0",
@@ -3054,9 +3054,9 @@
       }
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -3278,9 +3278,9 @@
       "optional": true
     },
     "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sshpk": {
       "version": "1.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix-migrate",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix-migrate",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix-migrate",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A command-line tool to migrate data to and from Netflix profiles",
   "keywords": [
     "netflix",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "array.prototype.find": "^2.0.0",
     "async": "^2.0.0-rc.5",
     "commander": "^2.9.0",
-    "netflix2": "0.0.8",
+    "netflix2": "0.1.1",
     "prompt": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix-migrate",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A command-line tool to migrate data to and from Netflix profiles",
   "keywords": [
     "netflix",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "netflix-migrate": "./index.js"
   },
   "scripts": {
-    "test": "nyc --reporter=text --check-coverage mocha main.test.js",
+    "test": "nyc --reporter=text --check-coverage --lines 100 mocha main.test.js",
     "test-without-coverage": "mocha main.test.js"
   },
   "dependencies": {


### PR DESCRIPTION
netflix2 version 0.1.1 allows you to set thumb type ratings. From now on, the import command can differentiate between star and thumb ratings and sets both correctly, instead of turning a thumb rating into a two-star rating.

This PR also adds some more tests to get the coverage up to 100% again. Coverage will now fail an npm test; sorry for disabeling that!