### PR TITLE
Add viewing history and version to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ npm install -g netflix-migrate
 
 ## Usage
 ```
-netflix-migrate --email old@example.com --profile Lana --export ratings.json
-netflix-migrate --email new@example.com --profile Lana --import ratings.json
+netflix-migrate --email old@example.com --profile Lana --export netflixData.json
+netflix-migrate --email new@example.com --profile Lana --import netflixData.json
 ```
 You will be prompted for your email address, password, and/or profile name if not provided as a parameter. If you do not specify a file path for `--export` or `--import`, `stdout` and `stdin` will be used, respectively. If `--export` or `--import` are not provided, `--export` is assumed (and `stdout` will be used).
+
+Your exported data will also contain your viewing history. Currently, the import function is only able to import the rating history, but that will hopefully change soon. However, you now already have your data and once the functionality is added you will be able to import your old viewing history too, even if you don't have any access to the old account anymore.
 
 ## Warning
 

--- a/main.js
+++ b/main.js
@@ -35,7 +35,8 @@ async function main(args, netflix = new Netflix()) {
 
     if (args.shouldExport) {
       const filename = args.export === true ? undefined : args.export;
-      await main.getRatingHistory(netflix, filename, args.spaces);
+      const ratingHistory = await main.getRatingHistory(netflix);
+      main.writeToChosenOutput(ratingHistory, filename, args.spaces);
     } else {
       const filename = args.import === true ? undefined : args.import;
       await main.setRatingHistory(netflix, filename);
@@ -109,27 +110,34 @@ main.switchProfile = async function(netflix, guid) {
  * Gets rating history from current profile and prints it
  * to console or specified file
  * @param {Netflix} netflix
- * @param {String} [fileName]
- * @param {Number | Null} spaces
- * @returns {Promise} Promise that is resolved once rating history has been fetched
- * @todo make pure by extracting spaces into parameter
+ * @returns {Promise} Promise that is resolved with rating history once it has been fetched
  */
-main.getRatingHistory = async function(netflix, fileName, spaces) {
+main.getRatingHistory = async function(netflix) {
   let ratings;
   
   try {
     ratings = await netflix.getRatingHistory();
+    return ratings;
   } catch (e) {
     console.error(e);
     throw new Error('Could not retrieve rating history. For more information, please see previous log statements.');
   }
-  
-  const jsonRatings = JSON.stringify(ratings, null, spaces);
+};
+
+/**
+ * Writes a natove Object's JSON representation either to a file, if the file name
+ * is specified, or to process.stdout
+ * @param {Object} data
+ * @param {String} [fileName]
+ * @param {Number | String} [numberOfSpaces]
+ */
+main.writeToChosenOutput = (data, fileName, numberOfSpaces) => {
+  const dataJson = JSON.stringify(data, null, numberOfSpaces);
 
   if (fileName === undefined) {
-    process.stdout.write(jsonRatings);
+    process.stdout.write(dataJson);
   } else {
-    fs.writeFileSync(fileName, jsonRatings);
+    fs.writeFileSync(fileName, dataJson);
   }
 };
 

--- a/main.js
+++ b/main.js
@@ -107,8 +107,7 @@ main.switchProfile = async function(netflix, guid) {
 };
 
 /**
- * Gets rating history from current profile and prints it
- * to console or specified file
+ * Gets rating history from current profile
  * @param {Netflix} netflix
  * @returns {Promise} Promise that is resolved with rating history once it has been fetched
  */
@@ -121,6 +120,23 @@ main.getRatingHistory = async function(netflix) {
   } catch (e) {
     console.error(e);
     throw new Error('Could not retrieve rating history. For more information, please see previous log statements.');
+  }
+};
+
+/**
+ * Gets viewing history from current profile
+ * @param {Netflix} netflix
+ * @returns {Promise} Promise that is resolved with viewing history once it has been fetched
+ */
+main.getViewingHistory = async function(netflix) {
+  let viewingHistory;
+  
+  try {
+    viewingHistory = await netflix.getViewingHistory();
+    return viewingHistory;
+  } catch (e) {
+    console.error(e);
+    throw new Error('Could not retrieve viewing history. For more information, please see previous log satements.')
   }
 };
 

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ Netflix.prototype.login = util.promisify(Netflix.prototype.login);
 Netflix.prototype.getProfiles = util.promisify(Netflix.prototype.getProfiles);
 Netflix.prototype.switchProfile = util.promisify(Netflix.prototype.switchProfile);
 Netflix.prototype.getRatingHistory = util.promisify(Netflix.prototype.getRatingHistory);
+Netflix.prototype.getViewingHistory = util.promisify(Netflix.prototype.getViewingHistory);
 Netflix.prototype.setStarRating = util.promisify(Netflix.prototype.setStarRating);
 Netflix.prototype.setThumbRating = util.promisify(Netflix.prototype.setThumbRating);
 const sleep = util.promisify(setTimeout);
@@ -36,7 +37,12 @@ async function main(args, netflix = new Netflix()) {
     if (args.shouldExport) {
       const filename = args.export === true ? undefined : args.export;
       const ratingHistory = await main.getRatingHistory(netflix);
-      main.writeToChosenOutput(ratingHistory, filename, args.spaces);
+      const viewingHistory = await main.getViewingHistory(netflix);
+      const dataToBeSaved = {
+        ratingHistory: ratingHistory,
+        viewingHistory: viewingHistory
+      };
+      main.writeToChosenOutput(dataToBeSaved, filename, args.spaces);
     } else {
       const filename = args.import === true ? undefined : args.import;
       await main.setRatingHistory(netflix, filename);

--- a/main.js
+++ b/main.js
@@ -51,7 +51,7 @@ async function main(args, netflix = new Netflix()) {
 			main.writeToChosenOutput(dataToBeSaved, filename, args.spaces);
 		} else {
 			const filename = args.import === true ? undefined : args.import;
-			const savedData = main.readDataFromChosenOutput(filename);
+			const savedData = main.readDataFromChosenInput(filename);
 			await main.setRatingHistory(netflix, savedData.ratingHistory);
 		}
 	} catch (e) {
@@ -175,7 +175,7 @@ main.writeToChosenOutput = (data, fileName, numberOfSpaces) => {
  * stdout and parses rating history and viewing history
  * @param {String} [fileName]
  */
-main.readDataFromChosenOutput = (fileName) => {
+main.readDataFromChosenInput = (fileName) => {
 	let dataJSON;
 	
 	if (fileName === undefined) {

--- a/main.test.js
+++ b/main.test.js
@@ -8,7 +8,7 @@ chai.use(sinonChai);
 
 const main = require('./main');
 const {waterfall, getProfileGuid, switchProfile, getRatingHistory, getViewingHistory, setRatingHistory, exitWithMessage,
-	writeToChosenOutput, readDataFromChosenOutput} = main;
+	writeToChosenOutput, readDataFromChosenInput} = main;
 const Netflix = require('netflix2');
 const fs = require('fs');
 
@@ -436,7 +436,7 @@ describe('getViewingHistory', () => {
 	});
 });
 
-describe('readDataFromChosenOutput', () => {
+describe('readDataFromChosenInput', () => {
 	let fsReadFileSync, processStdinRead, jsonParse;
 	
 	const ratings = [
@@ -490,33 +490,33 @@ describe('readDataFromChosenOutput', () => {
 	});
 	
 	it('Should read its data from stdin when no filename is specified', () => {
-		readDataFromChosenOutput();
+		readDataFromChosenInput();
 		expect(processStdinRead).to.have.been.calledOnce;
 		expect(fsReadFileSync).to.not.have.been.called;
 	});
 	
 	it('Should read its data from a file when a filename is specified', () => {
-		readDataFromChosenOutput(filename);
+		readDataFromChosenInput(filename);
 		expect(fsReadFileSync).to.have.been.calledOnce;
 		expect(fsReadFileSync).to.have.been.calledWith(filename);
 		expect(processStdinRead).to.not.have.been.called;
 	});
 	
 	it('Should call JSON.parse to convert JSON from stdin to an object', () => {
-		readDataFromChosenOutput();
+		readDataFromChosenInput();
 		expect(jsonParse).to.have.been.calledOnce;
 		expect(jsonParse).to.have.been.calledWithExactly(totalHistoryJSON);
 	});
 	
 	it('Should call JSON.parse to convert JSON from file to an object', () => {
-		readDataFromChosenOutput(filename);
+		readDataFromChosenInput(filename);
 		expect(jsonParse).to.have.been.calledOnce;
 		expect(jsonParse).to.have.been.calledWithExactly(totalHistoryJSON);
 	});
 	
 	it('Should always return an object with the properties ratingHistory and viewingHistory', () => {
-		const calledWithFilename = readDataFromChosenOutput(filename);
-		const calledWithoutFilename = readDataFromChosenOutput();
+		const calledWithFilename = readDataFromChosenInput(filename);
+		const calledWithoutFilename = readDataFromChosenInput();
 		
 		for (let call of [calledWithFilename, calledWithoutFilename]) {
 			expect(call).to.be.instanceOf(Object);
@@ -532,7 +532,7 @@ describe('readDataFromChosenOutput', () => {
 		});
 		
 		it('Should return a ratingHitory of data and a viewingHistory & version of null', () => {
-			const result = readDataFromChosenOutput();
+			const result = readDataFromChosenInput();
 			expect(result.ratingHistory).to.deep.equal(ratings);
 			expect(result.viewingHistory).to.be.null;
 			expect(result.version).to.be.null;
@@ -541,7 +541,7 @@ describe('readDataFromChosenOutput', () => {
 	
 	describe('When finding an object (data from v0.3.0 or higher)', () => {
 		it('Should return the correct version number, rating and viewing histories', () => {
-			const result = readDataFromChosenOutput();
+			const result = readDataFromChosenInput();
 			expect(result.version).to.deep.equal(totalHistory.version);
 			expect(result.ratingHistory).to.deep.equal(ratings);
 			expect(result.viewingHistory).to.deep.equal(views);
@@ -585,7 +585,7 @@ describe('readDataFromChosenOutput', () => {
 				processStdinRead.returns(scenario.JSON);
 				fsReadFileSync.returns(scenario.JSON);
 				
-				expect(() => readDataFromChosenOutput()).to.throw();
+				expect(() => readDataFromChosenInput()).to.throw();
 			});
 		}
 	});
@@ -722,7 +722,7 @@ describe('setRatingHistory', () => {
 
 describe('main', () => {
 	let netflix, netflixLogin, mainGetProfileGuid, mainSwitchProfile, mainGetRatingHistory, mainGetViewingHistory,
-		mainSetRatingHistory, mainExitWithMessage, mainWriteToChosenOutput, mainReadDataFromChosenOutput, stubs, args;
+		mainSetRatingHistory, mainExitWithMessage, mainWriteToChosenOutput, mainReadDataFromChosenInput, stubs, args;
 	const profile = {guid: 1234567890, firstName: 'Foo'};
 	const ratings = [
 		{
@@ -778,13 +778,13 @@ describe('main', () => {
 		
 		mainWriteToChosenOutput = sinon.stub(main, 'writeToChosenOutput');
 		
-		mainReadDataFromChosenOutput = sinon.stub(main, 'readDataFromChosenOutput')
+		mainReadDataFromChosenInput = sinon.stub(main, 'readDataFromChosenInput')
 			.returns(data);
 		
 		stubs = [
 			netflixLogin, mainExitWithMessage, mainGetProfileGuid, mainSwitchProfile,
 			mainGetRatingHistory, mainGetViewingHistory, mainSetRatingHistory, mainWriteToChosenOutput,
-			mainReadDataFromChosenOutput
+			mainReadDataFromChosenInput
 		];
 	});
 	
@@ -909,31 +909,31 @@ describe('main', () => {
 		});
 	});
 	
-	describe('Should call main.readDataFromChosenOutput', () => {
+	describe('Should call main.readDataFromChosenInput', () => {
 		beforeEach(() => {
 			args.shouldExport = false;
 		});
 		
 		it('if args.shouldExport is false', async () => {
 			await main(args, netflix);
-			expect(mainReadDataFromChosenOutput).to.have.been.calledOnce;
+			expect(mainReadDataFromChosenInput).to.have.been.calledOnce;
 		});
 		
 		it('with an undefined filename if args.import is true', async () => {
 			args.import = true;
 			await main(args, netflix);
-			expect(mainReadDataFromChosenOutput).to.have.been.calledOnceWithExactly(undefined);
+			expect(mainReadDataFromChosenInput).to.have.been.calledOnceWithExactly(undefined);
 		});
 		
 		it('with filename provided in args.import', async () => {
 			args.import = {foo: 'bar'};
 			await main(args, netflix);
-			expect(mainReadDataFromChosenOutput).to.have.been.calledOnceWithExactly(args.import);
+			expect(mainReadDataFromChosenInput).to.have.been.calledOnceWithExactly(args.import);
 		});
 		
 		it('after main.switchProfile', async () => {
 			await main(args, netflix);
-			expect(mainReadDataFromChosenOutput).to.have.been.calledAfter(mainSwitchProfile);
+			expect(mainReadDataFromChosenInput).to.have.been.calledAfter(mainSwitchProfile);
 		});
 	});
 	
@@ -948,16 +948,16 @@ describe('main', () => {
 			expect(mainGetRatingHistory).to.not.have.been.called;
 		});
 		
-		it('with the rating history of the object returned by main.readDataFromChosenOutput', async () => {
+		it('with the rating history of the object returned by main.readDataFromChosenInput', async () => {
 			const obj = {version: 'bar', viewingHistory: 'cool movies', ratingHistory: 1234567890};
-			mainReadDataFromChosenOutput.returns(obj);
+			mainReadDataFromChosenInput.returns(obj);
 			await main(args, netflix);
 			expect(mainSetRatingHistory).to.have.been.calledOnceWithExactly(netflix, obj.ratingHistory);
 		});
 		
-		it('after main.readDataFromChosenOutput', async () => {
+		it('after main.readDataFromChosenInput', async () => {
 			await main(args, netflix);
-			expect(mainSetRatingHistory).to.have.been.calledAfter(mainReadDataFromChosenOutput);
+			expect(mainSetRatingHistory).to.have.been.calledAfter(mainReadDataFromChosenInput);
 		});
 	});
 	
@@ -971,11 +971,14 @@ describe('main', () => {
 		
 		const functionsToTest = [
 			// @todo make this work with netflix
-			// { name: 'netflix.login', parent: netflix },
-			{name: 'main.getProfileGuid', parent: main, args: {}},
-			{name: 'main.switchProfile', parent: main, args: {}},
-			{name: 'main.getRatingHistory', parent: main, args: {shouldExport: true}},
-			{name: 'main.setRatingHistory', parent: main, args: {shouldExport: false}}
+			// {name: 'netflix.login', parent: netflix, args: {}},
+			{name: 'main.getProfileGuid', parent: main, args: {}, type: 'promise'},
+			{name: 'main.switchProfile', parent: main, args: {}, type: 'promise'},
+			{name: 'main.getRatingHistory', parent: main, args: {shouldExport: true}, type: 'promise'},
+			{name: 'main.getViewingHistory', parent: main, args: {shouldExport: true}, type: 'promise'},
+			{name: 'main.writeToChosenOutput', parent: main, args: {shouldExport: true}, type: 'function'},
+			{name: 'main.readDataFromChosenInput', parent: main, args: {shouldExport: false}, type: 'function'},
+			{name: 'main.setRatingHistory', parent: main, args: {shouldExport: false}, type: 'promise'}
 		];
 		
 		for (let i = 0; i < functionsToTest.length; i++) {
@@ -983,17 +986,18 @@ describe('main', () => {
 			
 			it(`by ${func.name}`, async () => {
 				const err = new Error();
-				const parts = func.name.split('.');
-				func.parent[parts[1]].rejects(err);
+				
+				const nameOfFunction = func.name.split('.')[1];
+				if (func.type === 'promise') {
+					func.parent[nameOfFunction].rejects(err);
+				} else {
+					func.parent[nameOfFunction].throws(err);
+				}
+				
 				await main(func.args, netflix);
+				
 				expect(mainExitWithMessage).to.have.been.calledOnce;
 				expect(mainExitWithMessage).to.have.been.calledOnceWithExactly(err);
-				
-				for (let j = i + 1; j < functionsToTest.length; j++) {
-					const laterFunctionName = functionsToTest[j].name.split('.')[1];
-					const laterFunction = functionsToTest[j].parent[laterFunctionName];
-					expect(laterFunction).to.not.have.been.called;
-				}
 			});
 		}
 	});

--- a/main.test.js
+++ b/main.test.js
@@ -7,7 +7,7 @@ chai.use(chaiAsPromised);
 chai.use(sinonChai);
 
 const main = require('./main');
-const {waterfall, getProfileGuid, switchProfile, getRatingHistory, setRatingHistory, exitWithMessage, writeToChosenOutput} = main;
+const {waterfall, getProfileGuid, switchProfile, getRatingHistory, getViewingHistory, setRatingHistory, exitWithMessage, writeToChosenOutput} = main;
 const Netflix = require('netflix2');
 const fs = require('fs');
 
@@ -330,19 +330,19 @@ describe('getRatingHistory', () => {
 	it('Should return a promise', () => {
 		expect(getRatingHistory(netflix)).to.be.instanceOf(Promise);
 	});
-
+	
 	it('Should call netflix.getRatingsHistory()', async () => {
 		await getRatingHistory(netflix);
-
+		
 		expect(netflixGetRatingHistory).to.have.been.calledOnce;
 		expect(netflixGetRatingHistory).to.have.been.calledWithExactly();
 	});
-
+	
 	it('Should resolve with the result of netflix.getRatingHistory', async () => {
 		await expect(getRatingHistory(netflix)).to.eventually.deep.equal(ratings);
 	});
 	
-	it('Should log any error thrown by netflix.switchProfile', async () => {
+	it('Should log any error thrown by netflix.getRatingHistory', async () => {
 		const error = new Error('Error thrown by test');
 		netflixGetRatingHistory.rejects(error);
 		
@@ -356,10 +356,82 @@ describe('getRatingHistory', () => {
 		}
 	});
 	
-	it('Should throw an error when netflix.switchProfile throws an error', async () => {
+	it('Should throw an error when netflix.getRatingHistory throws an error', async () => {
 		netflixGetRatingHistory.rejects(new Error());
 		
 		await expect(getRatingHistory(netflix)).to.eventually.be.rejected;
+	});
+});
+
+describe('getViewingHistory', () => {
+	let netflix, netflixGetViewingHistory, consoleError;
+	const viewingHistory = [
+		{
+			'ratingType': 'star',
+			'title': 'Some movie',
+			'movieID': 12345678,
+			'yourRating': 5,
+			'intRating': 50,
+			'date': '01/02/2016',
+			'timestamp': 1234567890123,
+			'comparableDate': 1234567890
+		},
+		{
+			'ratingType': 'thumb',
+			'title': 'Amazing Show',
+			'movieID': 87654321,
+			'yourRating': 2,
+			'date': '02/02/2018',
+			'timestamp': 2234567890123,
+			'comparableDate': 2234567890
+		}
+	];
+	
+	beforeEach(() => {
+		netflix = new Netflix();
+		netflixGetViewingHistory = sinon.stub(netflix, 'getViewingHistory')
+			.resolves(viewingHistory);
+		consoleError = sinon.stub(console, 'error');
+	});
+	
+	afterEach(() => {
+		netflixGetViewingHistory.restore();
+		consoleError.restore();
+	});
+	
+	it('Should return a promise', () => {
+		expect(getViewingHistory(netflix)).to.be.instanceOf(Promise);
+	});
+
+	it('Should call netflix.getRatingsHistory()', async () => {
+		await getViewingHistory(netflix);
+
+		expect(netflixGetViewingHistory).to.have.been.calledOnce;
+		expect(netflixGetViewingHistory).to.have.been.calledWithExactly();
+	});
+
+	it('Should resolve with the result of netflix.getViewingHistory', async () => {
+		await expect(getViewingHistory(netflix)).to.eventually.deep.equal(viewingHistory);
+	});
+	
+	it('Should log any error thrown by netflix.getViewingHistory', async () => {
+		const error = new Error('Error thrown by test');
+		netflixGetViewingHistory.rejects(error);
+		
+		try {
+			await getViewingHistory(netflix);
+		} catch (e) {
+		
+		} finally {
+			expect(consoleError).to.have.been.calledOnce;
+			expect(consoleError).to.have.been.calledWithExactly(error);
+		}
+	});
+	
+	it('Should throw an error when netflix.getViewingHistory throws an error', async () => {
+		netflixGetViewingHistory.rejects(new Error());
+		
+		await expect(getViewingHistory(netflix)).to.eventually.be.rejected;
 	});
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix-migrate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix-migrate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A command-line tool to migrate data to and from Netflix profiles",
   "keywords": [
     "netflix",


### PR DESCRIPTION
The export function doesn't export just an array containing the rating history anymore. Instead, it exports an object, containing information about the current version of the package (just in case that information is needed in the future), the rating history **and** the viewing history.

The viewing history can not be imported yet. However, now users will always have that information and whenever the ability to import viewing history is added, they can just import their old data.

This version is also backwards compatible, as it can still import data from exports made with previous versions.